### PR TITLE
fixed the duration issue

### DIFF
--- a/images_to_video.py
+++ b/images_to_video.py
@@ -1,40 +1,58 @@
 import cv2
 import os
 
-def images_to_video(image_folder, output_video_file, fps=30):
+def resize_image(image, target_width, target_height):
+    """
+    Resize an image to fit within the specified dimensions while maintaining the original aspect ratio.
+    """
+    original_height, original_width = image.shape[:2]
+    aspect_ratio = original_width / original_height
+    
+    if original_width > original_height:
+        new_width = target_width
+        new_height = int(target_width / aspect_ratio)
+    else:
+        new_height = target_height
+        new_width = int(target_height * aspect_ratio)
+
+    resized_image = cv2.resize(image, (new_width, new_height))
+    
+    # If the new dimensions are smaller in any direction, pad the resized image with black color
+    top_padding = (target_height - new_height) // 2
+    bottom_padding = target_height - new_height - top_padding
+    left_padding = (target_width - new_width) // 2
+    right_padding = target_width - new_width - left_padding
+
+    return cv2.copyMakeBorder(resized_image, top_padding, bottom_padding, left_padding, right_padding, cv2.BORDER_CONSTANT, value=[0, 0, 0])
+
+def images_to_video(image_folder, output_video_file, fps=30, duration=5, target_width=1920, target_height=1080):
     """
     Convert a set of images in a folder to a video.
     
     Parameters:
     - image_folder: path to the folder containing the images
-    - output_video_file: path to the output video file (e.g., 'output.avi')
+    - output_video_file: path to the output video file (e.g., 'output.mp4')
     - fps: frames per second for the output video
+    - duration: duration in seconds for each image to be displayed
+    - target_width: width to resize images to
+    - target_height: height to resize images to
     """
     
-    # Get all files from the folder
     images = [img for img in os.listdir(image_folder) if img.endswith(".png")]
-    
-    # Sort the images by name
     images.sort()
+
+    out = cv2.VideoWriter(output_video_file, cv2.VideoWriter_fourcc(*'XVID'), fps, (target_width, target_height))
     
-    # Determine the width and height from the first image
-    frame = cv2.imread(os.path.join(image_folder, images[0]))
-    h, w, layers = frame.shape
-    size = (w,h)
-    
-    # Create a video writer object
-    out = cv2.VideoWriter(output_video_file, cv2.VideoWriter_fourcc(*'DIVX'), fps, size)
-    
-    # Write each image to the video writer
     for image in images:
         img_path = os.path.join(image_folder, image)
         img = cv2.imread(img_path)
-        out.write(img)
+        
+        resized_img = resize_image(img, target_width, target_height)
+        
+        for _ in range(fps * duration):  # This will make each image last for 'duration' seconds
+            out.write(resized_img)
     
-    # Release the video writer object
     out.release()
 
 # Example usage:
-# images_to_video('path_to_image_folder', 'output_video.avi', fps=30)
-
-images_to_video('images', 'outout_video.avi', fps=30)
+# images_to_video('path_to_image_folder', 'output_video.mp4', fps=30, duration=5)


### PR DESCRIPTION
This branch fixes https://github.com/kashfifahim/images-to-video-file/issues/1#issue-1957817110 

In the earlier script, the first image provides the dimensions for each frame of the movie. However, if the second image doesn't match the dimensions of that first image, the image was not being added.

To fix this added a new function ```resize_image``` that takes an image and resizes the image. This way the output video file has all the images. 

Passed simple test case with a folder with 4 screenshots of different sizes.